### PR TITLE
EHT-3663 Revert "chore: migrate supernode to evm support keys"

### DIFF
--- a/group_vars/testnet.yml
+++ b/group_vars/testnet.yml
@@ -138,7 +138,7 @@ lumera:
   snapshot_url: https://snapshots.polkachu.com/testnet-snapshots/lumera/lumera_712731.tar.lz4
   supernode:
     version: v2.6.1-testnet
-    identity: lumera1wmq0wu60a63cnx5fhln0m0zv6u5rq6dw0dhvhn
+    identity: lumera186822tfvchl7dyj52wmy4e8jrudcfk4ddv0w6n
     keyfile_name: 3e8ea52d2cc5ffe6925453b64ae4f21f1b84daad.address
     grpc_addr: localhost:15090
 

--- a/roles/supernode/templates/testnet/config.yml.j2
+++ b/roles/supernode/templates/testnet/config.yml.j2
@@ -1,6 +1,5 @@
 supernode:
-    key_name: supernode-legacy
-    evm_key_name: supernode
+    key_name: supernode
     identity: {{ lumera.supernode.identity }}
     host: {{ ansible_default_ipv4.address }}
     port: {{ lumera.supernode.ports.listen_port }}


### PR DESCRIPTION
This reverts commit 31c8d66f7741d511f2ca8bfc8095c49d09fbc40e.